### PR TITLE
Allow parsing unambiguous DMY even if `prefer_mdy` is false

### DIFF
--- a/dateparser/src/datetime.rs
+++ b/dateparser/src/datetime.rs
@@ -117,9 +117,15 @@ where
             return None;
         }
         if self.prefer_dmy {
-            self.slash_dmy_hms(input).or_else(|| self.slash_dmy(input))
+            self.slash_dmy_hms(input)
+                .or_else(|| self.slash_dmy(input))
+                .or_else(|| self.slash_mdy_hms(input))
+                .or_else(|| self.slash_mdy(input))
         } else {
-            self.slash_mdy_hms(input).or_else(|| self.slash_mdy(input))
+            self.slash_mdy_hms(input)
+                .or_else(|| self.slash_mdy(input))
+                .or_else(|| self.slash_dmy_hms(input))
+                .or_else(|| self.slash_dmy(input))
         }
     }
 

--- a/dateparser/src/lib.rs
+++ b/dateparser/src/lib.rs
@@ -586,5 +586,6 @@ mod tests {
     #[test]
     fn parse_unambiguous_dmy() {
         assert_eq!(super::parse("31/3/22").unwrap().date(), Utc.ymd(2022, 3, 31));
+        assert_eq!(super::parse_with_preference("3/31/22", true).unwrap().date(), Utc.ymd(2022, 3, 31));
     }
 }

--- a/dateparser/src/lib.rs
+++ b/dateparser/src/lib.rs
@@ -582,4 +582,9 @@ mod tests {
             };
         }
     }
+
+    #[test]
+    fn parse_unambiguous_dmy() {
+        assert_eq!(super::parse("31/3/22").unwrap().date(), Utc.ymd(2022, 3, 31));
+    }
 }


### PR DESCRIPTION
Even if `prefer_mdy` is false, we should still allow parsing unambiguous MDY like "31/3/22". Right now, that fails.

This PR allows parsing dates like "31/3/22" even if `prefer_mdy` is false, and allows parsing "3/31/22" even if `prefer_mdy` is true.
